### PR TITLE
Added bounds to xtensor dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
             cmake
             ninja
             xtl
-            xtensor
+            xtensor>=0.27,<0.28
             fftw
             gtest
 


### PR DESCRIPTION
I know the CI is already pulling xtensor 0.27.1, but let's make it explicit, and then release a new version based on xtensor 0.27, so that the feedstock and this repo are aligned.